### PR TITLE
Use C layout for `ArcInner` and `RcInner`

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -23,6 +23,7 @@ const BARRIER: ucount = 256;
 #[cfg(target_pointer_width = "32")]
 const BARRIER: ucount = 8;
 
+#[repr(C)]
 struct ArcInner<T> {
     data: UnsafeCell<T>,
     counter: AtomicCounter,

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -11,6 +11,7 @@ use core::{
     ptr::NonNull,
 };
 
+#[repr(C)]
 struct RcInner<T> {
     data: UnsafeCell<T>,
     counter: UnsafeCell<ucount>,


### PR DESCRIPTION
I'll check to see if anyone points out any issues after I take a nap, otherwise I would say this is good to merge. Both `cargo test` and `miri` are happy even with `-Z randomize-layout` after this change

_Sidenote: It would be good to get CI running with at least `cargo test` and `miri` since this uses `unsafe`_