### PR TITLE
Match other implementations

### DIFF
--- a/src/rc.rs
+++ b/src/rc.rs
@@ -311,6 +311,12 @@ impl<T> Rc<T> {
             Err(this)
         }
     }
+
+    // Non-inlined part of `drop`. Just invokes the destructor.
+    #[inline(never)]
+    unsafe fn drop_slow(&mut self) {
+        let _ = Box::from_raw(self.ptr.as_mut());
+    }
 }
 
 impl<T: Clone> Rc<T> {
@@ -470,7 +476,7 @@ impl<T> Drop for Rc<T> {
             let value = value.wrapping_sub(1);
             counter.set(value);
         } else {
-            unsafe { Box::from_raw(self.ptr.as_mut()) };
+            unsafe { self.drop_slow() };
         }
     }
 }

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -313,7 +313,6 @@ impl<T> Rc<T> {
     }
 
     // Non-inlined part of `drop`. Just invokes the destructor.
-    #[inline(never)]
     unsafe fn drop_slow(&mut self) {
         let _ = Box::from_raw(self.ptr.as_mut());
     }


### PR DESCRIPTION
* Avoid inlining the destructor
* ~~Use a load specifically on `count` instead of a `fence`, this is what std and triomphe do.~~