### PR TITLE
Add optional enum-ptr feature

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --all-features --verbose
       - name: Test with Cargo
-        run: cargo test --verbose
+        run: cargo test --all-features --verbose
   cargo_test_release:
     name: "Cargo Test (Release)"
     runs-on: ubuntu-latest
@@ -29,9 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --release --verbose
+        run: cargo build --all-features --release --verbose
       - name: Test with Cargo (Release)
-        run: cargo test --release --verbose
+        run: cargo test --all-features --release --verbose
   miri_test:
     name: "Miri Test"
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test
+        run: cargo miri test --all-features
   miri_test_with_flags:
     name: "Miri Test (RUSTFLAGS)"
     env:
@@ -59,4 +59,4 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test
+        run: cargo miri test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ usize-for-small-platforms = []
 
 [dependencies]
 branches = "0.1"
+enum-ptr = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -735,3 +735,8 @@ impl<T> AsRef<T> for Arc<T> {
 }
 
 impl<T> Unpin for Arc<T> {}
+
+#[cfg(feature = "enum-ptr")]
+unsafe impl<T> enum_ptr::Aligned for Arc<T> {
+    const ALIGNMENT: usize = align_of::<ArcInner<T>>();
+}

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -640,3 +640,8 @@ impl<T> AsRef<T> for Rc<T> {
 }
 
 impl<T> Unpin for Rc<T> {}
+
+#[cfg(feature = "enum-ptr")]
+unsafe impl<T> enum_ptr::Aligned for Rc<T> {
+    const ALIGNMENT: usize = align_of::<RcInner<T>>();
+}

--- a/tests/arc.rs
+++ b/tests/arc.rs
@@ -45,3 +45,12 @@ fn multi_multithread() {
     }
     std::thread::sleep(Duration::from_millis(100));
 }
+
+#[cfg(feature = "enum-ptr")]
+#[test]
+fn aligned() {
+    // alignment: bool < ucount
+    assert_eq!(<Arc<bool> as enum_ptr::Aligned>::ALIGNMENT, 4);
+    // alignment: u128 > ucount
+    assert_eq!(<Arc<u128> as enum_ptr::Aligned>::ALIGNMENT, 16);
+}

--- a/tests/rc.rs
+++ b/tests/rc.rs
@@ -13,3 +13,12 @@ fn cloned() {
     let _c = a.clone();
     let _d = a;
 }
+
+#[cfg(feature = "enum-ptr")]
+#[test]
+fn aligned() {
+    // alignment: bool < ucount
+    assert_eq!(<Rc<bool> as enum_ptr::Aligned>::ALIGNMENT, 4);
+    // alignment: u128 > ucount
+    assert_eq!(<Rc<u128> as enum_ptr::Aligned>::ALIGNMENT, 16);
+}


### PR DESCRIPTION
Hey, thanks for creating this crate. I'm planning to use it, combined with a crate called `enum-ptr`: https://crates.io/crates/enum_ptr

`enum-ptr` provides a marker trait called `Aligned` (https://docs.rs/enum-ptr/latest/enum_ptr/trait.Aligned.html), which `rclite::{Rc, Arc}` needs to implement for our use case. So, this pr is adding optional feature to do so.

Along with it, this pr also adjusts the CI so that the newly added code is tested.